### PR TITLE
Also monitor window title updates.

### DIFF
--- a/IconMonitorHook/Main.cpp
+++ b/IconMonitorHook/Main.cpp
@@ -71,6 +71,11 @@ extern "C" __declspec(dllexport) LRESULT Hookproc(int code, WPARAM sent_by_curre
         if (cwp->message == WM_SETICON) {
             // cwp->lResult contains the prev. icon handle
             OnIconUpdated(cwp->hwnd, cwp->wParam, (HICON)cwp->lParam);
+        } else if (cwp->message == WM_SETTEXT) {
+            // log window title updates in Visual Studio "Output" window
+            OutputDebugStringW(L"WM_SETTEXT: ");
+            OutputDebugStringW((wchar_t*)cwp->lParam);
+            OutputDebugStringW(L"\n");
         }
     }
 

--- a/MyWindowsApp/IconHandle.hpp
+++ b/MyWindowsApp/IconHandle.hpp
@@ -46,7 +46,7 @@ class IconHandle {
 public:
     IconHandle() = default;
 
-    IconHandle(HICON icon, bool destroy) : m_icon(icon), m_destroy(destroy) {
+    IconHandle(HICON icon, std::wstring title, bool destroy) : m_icon(icon), m_title(title), m_destroy(destroy) {
     }
 
     ~IconHandle() {
@@ -64,8 +64,13 @@ public:
     }
 
 
+    const wchar_t* Title() const {
+        return m_title.c_str();
+    }
+
     void Swap(IconHandle & other) {
         std::swap(m_icon, other.m_icon);
+        std::swap(m_title, other.m_title);
         std::swap(m_destroy, other.m_destroy);
     }
 
@@ -79,6 +84,7 @@ public:
         // res contains prev icon handle
     }
 private:
-    HICON m_icon = 0;
-    bool  m_destroy = false; ///< destroy on close
+    HICON        m_icon = 0;
+    std::wstring m_title;
+    bool         m_destroy = false; ///< destroy on close
 };

--- a/MyWindowsApp/Main.cpp
+++ b/MyWindowsApp/Main.cpp
@@ -67,8 +67,8 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine
 
 LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
     if (!m_titlebar) {
-        m_titlebar = IconHandle(LoadIconW(NULL, IDI_EXCLAMATION), false);
-        m_taskbar = IconHandle(CreateIconFromRGB(hwnd), true);
+        m_titlebar = IconHandle(LoadIconW(NULL, IDI_EXCLAMATION), L"Title 1", false);
+        m_taskbar = IconHandle(CreateIconFromRGB(hwnd), L"Title 2", true);
     }
 
     switch (uMsg) {
@@ -91,6 +91,9 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
             m_titlebar.Swap(m_taskbar);
             m_titlebar.Activate(hwnd, ICON_BIG);
             m_taskbar.Activate(hwnd, ICON_SMALL);
+
+            // update window title (will trigger a WM_SETTEXT message)
+            SetWindowTextW(hwnd, m_titlebar.Title());
         }
         break;
     }


### PR DESCRIPTION
Fixes #8. Show how to also hook `WM_SETTEXT` events for window title updates. The events are actually transferred to the client yet. They're only detected in the hook DLL.

This will intercept updates to the "window caption" as shown in Spy++:
![image](https://github.com/forderud/IconMonitor/assets/2671400/ad1b5ec3-014a-41c6-85ef-2cec769db9a2)
